### PR TITLE
switch to an "event driven" style

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -1,22 +1,27 @@
-use std::sync::mpsc;
-use std::thread;
-
+use std::{
+    sync::{mpsc, mpsc::Receiver},
+    thread,
+    time::Duration,
+};
 use termion::event::Key;
 use termion::input::TermRead;
 
 pub enum Event<I> {
     Input(I),
+    Tick,
 }
 
 pub struct Events {
     rx: mpsc::Receiver<Event<Key>>,
     input_handle: thread::JoinHandle<()>,
+    tick_handle: thread::JoinHandle<()>,
 }
 
 impl Events {
-    pub fn new() -> Events {
+    pub fn new(tick_dur_recv: Receiver<Duration>) -> Events {
         let (tx, rx) = mpsc::channel();
         let input_handle = {
+            let tx = tx.clone();
             thread::spawn(move || match termion::get_tty() {
                 Ok(input) => {
                     for key in input.keys().filter_map(|evt| evt.ok()) {
@@ -29,10 +34,31 @@ impl Events {
                 Err(msg) => panic!("{}", msg),
             })
         };
-        Events { rx, input_handle }
+        let tick_handle = {
+            thread::spawn(move || loop {
+                match tick_dur_recv.recv() {
+                    Ok(dur) => {
+                        thread::sleep(dur);
+                        if let Err(err) = tx.send(Event::Tick) {
+                            eprintln!("{}", err);
+                            break;
+                        }
+                    }
+                    Err(err) => {
+                        eprintln!("{}", err);
+                        break;
+                    }
+                }
+            })
+        };
+        Events {
+            rx,
+            input_handle,
+            tick_handle,
+        }
     }
 
-    pub fn next(&self) -> Result<Event<Key>, mpsc::TryRecvError> {
-        self.rx.try_recv()
+    pub fn next(&self) -> Result<Event<Key>, mpsc::RecvError> {
+        self.rx.recv()
     }
 }


### PR DESCRIPTION
this seems to dramatically reduce CPU utilization, as we would expect
from removing an (unnecessary) busy loop which re-renders the screen
needlessly.

closes #3.